### PR TITLE
Add missed tools to github chat modes

### DIFF
--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -960,7 +960,7 @@ class IdeSetup {
         
         let chatmodeContent = `---
 description: "${description.replace(/"/g, '\\"')}"
-tools: ['changes', 'codebase', 'fetch', 'findTestFiles', 'githubRepo', 'problems', 'usages']
+tools: ['changes', 'codebase', 'fetch', 'findTestFiles', 'githubRepo', 'problems', 'usages', 'editFiles', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure']
 ---
 
 `;


### PR DESCRIPTION
## What

It adds tools to edit files and execute commands required for the agents to do their job

## Why

Without it, agents cannot write or edit files when using custom chat modes in GitHub Copilot.
Fixes #323

## How

Added some useful tools available in Copilot:
'editFiles', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure'

## Testing

Execute the chat mode with these tools, now the agents can write files and do their job